### PR TITLE
No need to double-escape things

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -76,12 +76,7 @@ class Button extends WP_Customize_Section {
 			$button_url = $theme->get( 'AuthorURI' );
 		}
 
-		$json['button_text'] = esc_html(
-			$this->button_text
-			? $this->button_text
-			: $theme->get( 'Name' )
-		);
-
+		$json['button_text'] = $this->button_text ? $this->button_text : $theme->get( 'Name' );
 		$json['button_url']  = esc_url( $button_url );
 
 		return $json;


### PR DESCRIPTION
`$json['button_text']` is already escaped on output in the JS template since we're using `{{ data.button_text }}` instead of `{{{ data.button_text }}}`.
There's no need to double-escape it when setting the `$json` properties.
It doesn't hurt, but it doesn't do much either.